### PR TITLE
t-1-Create-genre-cache (fix after review)

### DIFF
--- a/src/main/java/com/ag/movieland/dao/cache/CachedGenreDao.java
+++ b/src/main/java/com/ag/movieland/dao/cache/CachedGenreDao.java
@@ -5,18 +5,24 @@ import com.ag.movieland.entity.Genre;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Repository;
 
 import javax.annotation.PostConstruct;
+import java.util.ArrayList;
 import java.util.List;
 
+@Configuration
+@EnableScheduling
 @Primary
-@Repository("CachedGenreDao")
+@Repository
 public class CachedGenreDao implements IGenreDao {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
-    private List<Genre> cachedGenres;
+    private volatile List<Genre> cachedGenres;
 
     private IGenreDao genreDao;
 
@@ -31,8 +37,9 @@ public class CachedGenreDao implements IGenreDao {
     }
 
     @PostConstruct
+    @Scheduled(fixedDelayString = "${refresh-interval-millis}")
     public void initCachedGenres() {
-        cachedGenres = genreDao.findAll();
+        cachedGenres = new ArrayList<>(genreDao.findAll());
         logger.info("Genre cache has been refreshed. Total size of Genre cache is : {}", cachedGenres.size());
     }
 

--- a/src/main/webapp/WEB-INF/movieland-context.xml
+++ b/src/main/webapp/WEB-INF/movieland-context.xml
@@ -24,12 +24,6 @@
     <constructor-arg ref="dataSource"/>
 </bean>
 
-<task:annotation-driven scheduler="myScheduler"/>
-<task:scheduler id="myScheduler" pool-size="10"/>
-<task:scheduled-tasks scheduler="myScheduler">
-    <task:scheduled ref="CachedGenreDao" method="initCachedGenres" fixed-delay="${refresh-interval-millis}"/>
-</task:scheduled-tasks>
-
 <!--database-->
 <bean id="dataSource" class="org.postgresql.ds.PGSimpleDataSource">
     <property name="user" value="${db.user}"/>


### PR DESCRIPTION
fix afetr review
- added annotation instead of xml configuration
- marked List<Genre> cachedGenres as volatile
- created copy of List